### PR TITLE
fix: Bubble up database errors in `message-db` component

### DIFF
--- a/packages/message-db/message-db/src/lib/MessageDbClient.ts
+++ b/packages/message-db/message-db/src/lib/MessageDbClient.ts
@@ -28,6 +28,7 @@ export class MessageDbWriter {
       const position = BigInt(results.rows[0].write_message)
       return { type: "Written", position }
     } catch (err: any) {
+      // TODO: bubble the error up: it might not just be a conflict
       return { type: "ConflictUnknown" }
     }
   }
@@ -64,6 +65,7 @@ export class MessageDbWriter {
 
       await client.query("COMMIT")
     } catch (err: any) {
+      // TODO: bubble the error up: it might not just be a conflict
       await client.query("ROLLBACK")
       return { type: "ConflictUnknown" }
     } finally {


### PR DESCRIPTION
Seen by using `equinox-js` in practice: when we didn't configure the database connection details properly, the only thing that application engineer sees is:

> Error: Concurrency violation; aborting after 3 attempts.

Which is particularly unhelpful. We need to find a way to bubble up the database error, too.