### PR TITLE
fix: don't assume order when merging streams

### DIFF
--- a/packages/propeller/src/StreamsSink.mts
+++ b/packages/propeller/src/StreamsSink.mts
@@ -12,12 +12,8 @@ class Stream {
 
   merge(event: ITimelineEvent): void {
     const last = this.events[this.events.length - 1]
-    if (!last || last.index === event.index - 1n) {
-      this.events.push(event)
-      return
-    }
-    if (last.index > event.index) return
-    if (event.index > last.index) throw new Error("Unexpected gap")
+    if (last && last.index >= event.index) return
+    this.events.push(event)
   }
 }
 


### PR DESCRIPTION
At least once delivery guarantees are expected. As such it is perfectly
reasonable for the following scenario to happen

1. Receive events [1,2,3,4,5]
2. Process restarts
3. Receive event [3, 6, 7, 8]

As such we should not guard explicitly against gaps in the merge method.
