### PR TITLE
fix: use `Error` instead of `DOMException`

### DIFF
--- a/packages/propeller/src/Queue.ts
+++ b/packages/propeller/src/Queue.ts
@@ -88,7 +88,9 @@ export class AsyncQueue<T> {
     const value = this.queue.tryFind(predicate)
     if (value) return value
     return new Promise<T>((resolve, reject) => {
-      const abort = () => reject(new DOMException("The operation was aborted", "AbortError"))
+      const err = new Error("The operation was aborted");
+      err.name = "AbortError";
+      const abort = () => reject(err)
       if (signal.aborted) return abort()
       signal.addEventListener("abort", abort)
       this.pendingGets.add({


### PR DESCRIPTION
`DOMException` is not available in NodeJS. Instead, we use `Error` and set `name` explicitly, to have the same error shape as `DOMException(msg, name)` would have.