### PR TITLE
fix: flush checkpoint within the bounds of the promise so it can be awaited

### DIFF
--- a/packages/dynamo-store/source/src/DynamoStoreSource.test.mts
+++ b/packages/dynamo-store/source/src/DynamoStoreSource.test.mts
@@ -76,7 +76,7 @@ test("Correctly batches stream handling", async () => {
     { p: IndexStreamId.ofString("Cat-stream3"), i: 1, c: ["Something", "Something"] },
   ])
 
-  await expect(src.start(ctrl.signal)).rejects.toThrow("The operation was aborted")
+  await expect(src.start(ctrl.signal)).rejects.toThrow("operation was aborted")
   expect(streams.size).toBe(3)
   expect(Array.from(streams.values()).flat()).toHaveLength(4)
 })
@@ -199,7 +199,7 @@ test("loading event bodies", async () => {
   }
   await wait
   expect(received).toEqual(expectedStreams)
-  await expect(sourceP).rejects.toThrow("The operation was aborted")
+  await expect(sourceP).rejects.toThrow("operation was aborted")
 })
 
 test("starting from the tail of the store", async () => {

--- a/packages/propeller/src/StreamsSink.test.mts
+++ b/packages/propeller/src/StreamsSink.test.mts
@@ -49,7 +49,7 @@ describe("Concurrency", () => {
       ctrl.abort()
 
       expect(maxActive).toBe(concurrency)
-      await expect(sinkP).rejects.toThrow("This operation was aborted")
+      await expect(sinkP).rejects.toThrow("operation was aborted")
     },
   )
 })
@@ -77,7 +77,7 @@ test("Correctly merges batches", async () => {
 
   expect(invocations).toBe(10)
   expect(checkpoint).toHaveBeenCalledTimes(2)
-  await expect(sinkP).rejects.toThrow("This operation was aborted")
+  await expect(sinkP).rejects.toThrow("operation was aborted")
 })
 
 const mkSingleBatch = (
@@ -123,7 +123,7 @@ test("Correctly limits in-flight batches", async () => {
 
   // onComplete is called in order and for every batch
   expect(completed.mock.calls).toEqual([[0n], [1n], [2n], [3n], [4n], [5n]])
-  await expect(sinkP).rejects.toThrow("This operation was aborted")
+  await expect(sinkP).rejects.toThrow("operation was aborted")
 })
 
 test("Ensures at-most one handler is per stream", async () => {
@@ -162,5 +162,5 @@ test("Ensures at-most one handler is per stream", async () => {
 
   // onComplete is called in order and for every batch
   expect(completed.mock.calls).toEqual([[0n], [1n], [2n], [3n], [4n], [5n]])
-  await expect(sinkP).rejects.toThrow("This operation was aborted")
+  await expect(sinkP).rejects.toThrow("operation was aborted")
 })


### PR DESCRIPTION
In a testing scenario it would happen that jest would kill the JS VM before the checkpoint was flushed. This change guarantees flushing is complete when the source promise fulfils 