### PR TITLE
fix: use Promise.allSettled

### DIFF
--- a/packages/dynamo-store/source/package.json
+++ b/packages/dynamo-store/source/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.mts --sourcemap --format esm,cjs --dts --clean"
+    "build": "tsup src/index.mts --sourcemap --format esm,cjs --dts --clean",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@equinox-js/memory-store": "workspace:*",

--- a/packages/dynamo-store/source/src/DynamoStoreSource.test.mts
+++ b/packages/dynamo-store/source/src/DynamoStoreSource.test.mts
@@ -41,7 +41,7 @@ const waiter = () => {
   ] as const
 }
 
-const throwIfActive = (signal: AbortSignal) => (e: any) => {
+const throwIfActive = (signal: AbortSignal) => (e: unknown) => {
   if (!signal.aborted) throw e
 }
 

--- a/packages/message-db/message-db-consumer/tests/source.test.mts
+++ b/packages/message-db/message-db-consumer/tests/source.test.mts
@@ -33,7 +33,7 @@ const conn = MessageDbConnection.create(pool)
 const writer = conn.write
 afterAll(() => pool.end())
 
-const throwIfActive = (signal: AbortSignal) => (e: any) => {
+const throwIfActive = (signal: AbortSignal) => (e: unknown) => {
   if (!signal.aborted) throw e
 }
 

--- a/packages/propeller/src/FeedSource.mts
+++ b/packages/propeller/src/FeedSource.mts
@@ -127,15 +127,6 @@ export class TailingFeedSource extends EventEmitter {
       cancelAndThrow,
     )
 
-    const results = await Promise.allSettled([checkpointsP, sinkP, sourceP])
-    await checkpointWriter.flush().catch(() => {})
-
-    const errors = []
-    for (const result of results) {
-      if (result.status === "rejected") errors.push(result.reason)
-    }
-
-    if (errors.length === 1) throw errors[0]
-    if (errors.length > 1) throw new AggregateError(errors)
+    await Promise.all([checkpointsP, sinkP, sourceP]).finally(() => checkpointWriter.flush())
   }
 }

--- a/packages/propeller/src/FeedSource.test.mts
+++ b/packages/propeller/src/FeedSource.test.mts
@@ -14,7 +14,7 @@ class MemorySink implements Sink {
   addTracingAttrs = vi.fn()
 }
 
-const throwIfActive = (signal: AbortSignal) => (e: any) => {
+const throwIfActive = (signal: AbortSignal) => (e: unknown) => {
   if (!signal.aborted) throw e
 }
 

--- a/packages/propeller/src/FeedSource.test.mts
+++ b/packages/propeller/src/FeedSource.test.mts
@@ -14,6 +14,10 @@ class MemorySink implements Sink {
   addTracingAttrs = vi.fn()
 }
 
+const throwIfActive = (signal: AbortSignal) => (e: any) => {
+  if (!signal.aborted) throw e
+}
+
 function createCrawl(batches: Batch[]) {
   return async function* crawl(): AsyncIterable<Batch> {
     while (batches.length) {
@@ -83,12 +87,12 @@ test("Checkpointing happens asynchronously", async () => {
   }
   vi.spyOn(CheckpointWriter.prototype, "flush")
   expect(await checkpoints.load("TestGroup", "0")).toBe(0n)
-  const sourceP = source.start("0", ctrl.signal)
+  const sourceP = source.start("0", ctrl.signal).catch(throwIfActive(ctrl.signal))
   await checkpointReached
   expect(CheckpointWriter.prototype.flush).toHaveBeenCalledTimes(1)
   expect(checkpoints.commit).toHaveBeenCalledTimes(1)
   ctrl.abort()
   expect(await checkpoints.load("TestGroup", "0")).toBe(3n)
-  await expect(sourceP).rejects.toThrow("operation was aborted")
+  await sourceP
   expect(CheckpointWriter.prototype.flush).toHaveBeenCalledTimes(2)
 })

--- a/packages/propeller/src/FeedSource.test.mts
+++ b/packages/propeller/src/FeedSource.test.mts
@@ -93,6 +93,10 @@ test("Checkpointing happens asynchronously", async () => {
   expect(checkpoints.commit).toHaveBeenCalledTimes(1)
   ctrl.abort()
   expect(await checkpoints.load("TestGroup", "0")).toBe(3n)
+  expect(CheckpointWriter.prototype.flush).toHaveBeenCalledTimes(1)
   await sourceP
   expect(CheckpointWriter.prototype.flush).toHaveBeenCalledTimes(2)
+})
+
+test("Checkpoint is flushed on abort or source error", async () => {
 })


### PR DESCRIPTION
before this change aborting the signal passed to FeedSource would
trigger an immediate rejection of the sink promise while the source
promise would do some processing. As such Promise.all would reject
immediately, meaning we couldn't effectively wait for the post
processing of the source
