### PR TITLE
refactor: Codec.tryDecode renamed to decode

### DIFF
--- a/apps/example/src/domain/invoice-auto-emailer.ts
+++ b/apps/example/src/domain/invoice-auto-emailer.ts
@@ -103,7 +103,7 @@ export const createHandler = (config: Config.Config, emailSender?: ISendEmails) 
   return async (stream: StreamName, events: ITimelineEvent[]) => {
     const id = Invoice.Stream.tryMatch(stream)
     if (!id) return
-    const ev = Invoice.Events.codec.tryDecode(events[0])
+    const ev = Invoice.Events.codec.decode(events[0])
     if (ev?.type !== "InvoiceRaised") return
     await service.sendEmail(id, ev.data.payer_id, ev.data.amount)
   }

--- a/apps/example/src/entrypoints/reactions.ts
+++ b/apps/example/src/entrypoints/reactions.ts
@@ -20,7 +20,7 @@ const invoiceEmailer = InvoiceAutoEmailer.Service.create(config)
 function impliesInvoiceEmailRequired(streamName: StreamName, events: ITimelineEvent[]) {
   const id = Invoice.Stream.tryMatch(streamName)
   if (!id) return
-  const ev = Invoice.Events.codec.tryDecode(events[0])
+  const ev = Invoice.Events.codec.decode(events[0])
   if (ev?.type !== "InvoiceRaised") return
   return { id, payer_id: ev.data.payer_id, amount: ev.data.amount }
 }

--- a/apps/example/src/read-models/PayerReadModel.ts
+++ b/apps/example/src/read-models/PayerReadModel.ts
@@ -13,7 +13,7 @@ export const projection = { table: "payer", id: ["id"], version: "version"}
 function changes(stream: StreamName, events: ITimelineEvent[]): Change[] {
   const id = Payer.Stream.tryMatch(stream) 
   if (!id) return []
-  const event = Payer.Events.codec.tryDecode(events[events.length - 1])
+  const event = Payer.Events.codec.decode(events[events.length - 1])
   if (!event) return []
   const version = events[events.length - 1]!.index
   switch (event.type) {

--- a/apps/example/test/domain/invoice.test.ts
+++ b/apps/example/test/domain/invoice.test.ts
@@ -17,7 +17,7 @@ const raised: Events.Event = {
 describe("Codec", () => {
   test("roundtrips", () => {
     const encoded = Events.codec.encode(raised, null)
-    const decoded = Events.codec.tryDecode(encoded as any)
+    const decoded = Events.codec.decode(encoded as any)
     expect(decoded).toEqual(raised)
   })
 })

--- a/apps/example/test/domain/payer.test.ts
+++ b/apps/example/test/domain/payer.test.ts
@@ -15,7 +15,7 @@ const updated: Payer.Events.Event = {
 describe("Codec", () => {
   test("roundtrips", () => {
     const encoded = Payer.Events.codec.encode(updated, null)
-    const decoded = Payer.Events.codec.tryDecode(encoded as any)
+    const decoded = Payer.Events.codec.decode(encoded as any)
     expect(decoded).toEqual(updated)
   })
 })

--- a/docs/docs/core-concepts/codec.md
+++ b/docs/docs/core-concepts/codec.md
@@ -17,7 +17,7 @@ like this:
 
 ```ts
 const codec: Codec<Event, string> = {
-  tryDecode(ev): Event | undefined {
+  decode(ev): Event | undefined {
     const data = JSON.parse(ev.data || "{}")
     switch (ev.type) {
       case "CheckedIn":
@@ -78,6 +78,13 @@ const codec = Codec.map(
   }),
 )
 ```
+
+When upcasting is used the `decode` method of the resulting codec will drop
+events whose types are not included in the mapping. This is because it's a 
+common evolution in event sourced systems for events to become dead weight, or
+unnecessary. By providing an upcast mapping you've essentially defined exactly
+the events you care about and the codec will respect that by returning `undefined`
+for events outside the mapping, and throwing when your upcast fails.
 
 :::caution
 

--- a/docs/docs/core-concepts/codec.md
+++ b/docs/docs/core-concepts/codec.md
@@ -79,7 +79,7 @@ const codec = Codec.map(
 )
 ```
 
-When upcasting is used the `decode` method of the resulting codec will drop
+When upcasting is used, the `decode` method of the resulting codec will drop
 events whose types are not included in the mapping. This is because it's a 
 common evolution in event sourced systems for events to become dead weight, or
 unnecessary. By providing an upcast mapping you've essentially defined exactly

--- a/docs/docs/examples/hotel.md
+++ b/docs/docs/examples/hotel.md
@@ -21,7 +21,7 @@ type Event =
   | { type: "CheckedOut"; data: { at: Date } }
 
 const codec: ICodec<Event, string> = {
-  tryDecode(ev): Event | undefined {
+  decode(ev): Event | undefined {
     const data = JSON.parse(ev.data || "{}")
     switch (ev.type) {
       case "CheckedIn":

--- a/docs/docs/reactions/index.md
+++ b/docs/docs/reactions/index.md
@@ -66,7 +66,7 @@ async function handler(stream: string, events: ITimelineEvent[]) {
   const messageId = MessageId.parse(streamId)
   // We know that the MessageSent event is always the first event in the stream
   // and as such we do not need to check any other event
-  const ev = Message.codec.tryDecode(events[0])
+  const ev = Message.codec.decode(events[0])
   if (ev.type !== "MessageSent") return
   await notifier.sendNotifications(messageId, ev.data)
 }

--- a/docs/docs/reactions/pg-projections.md
+++ b/docs/docs/reactions/pg-projections.md
@@ -30,7 +30,7 @@ export const projection = { table: "payer", id: ["id"] }
 
 function changes(stream: string, events: ITimelineEvent[]): Change[] {
   const id = PayerId.parse(StreamName.parseId(stream))
-  const event = Payer.codec.tryDecode(events[events.length - 1])
+  const event = Payer.codec.decode(events[events.length - 1])
   if (!event) return []
   switch (event.type) {
     case "PayerProfileUpdated":
@@ -133,7 +133,7 @@ function change(id: AppointmentId, version: bigint, event: Appointment.Event) {
 function changes(streamName: string, events: ITimelineEvent[]): Change[] {
   const id = AppointmentId.parse(StreamName.parseId(streamName))
   const version = events[events.length - 1].index
-  return keepMap(events, Appointment.codec.tryDecode).map((ev) => change(id, version, ev))
+  return keepMap(events, Appointment.codec.decode).map((ev) => change(id, version, ev))
 }
 
 export const createHandler = (pool: Pool) => createProjection(projection, pool, changes)

--- a/docs/docs/reactions/projections.md
+++ b/docs/docs/reactions/projections.md
@@ -39,10 +39,10 @@ function change(payerId: PayerId, event: Payer.Event): Sql {
 
 function changes(streamName: string, events: ITimelineEvent[]): Sql[] {
   const payerId = PayerId.parse(StreamName.parseId(streamName))
-  const decodedEvents = keepMap(events, Payer.codec.tryDecode)
+  const decodedEvents = keepMap(events, Payer.codec.decode)
   const changes: Sql[] = []
   for (const event of events) {
-    const ev = Payer.codec.tryDecode(event)
+    const ev = Payer.codec.decode(event)
     if (!ev) continue
     changes.push(change(payerId, ev))
   }

--- a/docs/src/examples/guest-stay.ts
+++ b/docs/src/examples/guest-stay.ts
@@ -18,7 +18,7 @@ type Event =
   | { type: "CheckedOut"; data: { at: Date } }
 
 const codec: ICodec<Event, string> = {
-  tryDecode(ev): Event | undefined {
+  decode(ev): Event | undefined {
     const data = JSON.parse(ev.data || "{}")
     switch (ev.type) {
       case "CheckedIn":

--- a/packages/core/test/Codec.test.ts
+++ b/packages/core/test/Codec.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect } from "vitest"
 import { Codec } from "../src"
 import { z } from "zod"
-import { randomUUID } from "crypto"
 
 describe("Codec", () => {
   describe("json", () => {
@@ -15,7 +14,7 @@ describe("Codec", () => {
         id: undefined,
       })
       expect(
-        codec.tryDecode({
+        codec.decode({
           type: "Hello",
           data: '{"world":"hello"}',
           meta: undefined,
@@ -49,19 +48,19 @@ describe("Codec", () => {
       test("roundtrips", () => {
         const event = { type: "Hello", data: { hello: new Date() } }
         const encoded = codec.encode(event, undefined)
-        const decoded = codec.tryDecode(encoded as any)
+        const decoded = codec.decode(encoded as any)
         expect(decoded).toEqual(event)
       })
 
       test("fails if upcast fails", () => {
         const event = { type: "Hello", data: { hello: "hello" } }
         const encoded = codec.encode(event, undefined)
-        expect(() => codec.tryDecode(encoded as any)).toThrow()
+        expect(() => codec.decode(encoded as any)).toThrow()
       })
 
       test("ignores unconfigured event types", () => {
         const event = { type: "OldHello", data: JSON.stringify({ hallo: "hallo" }) }
-        expect(codec.tryDecode(event as any)).toEqual(undefined)
+        expect(codec.decode(event as any)).toEqual(undefined)
       })
 
       test("does not roundtrip complex types", () => {
@@ -70,7 +69,7 @@ describe("Codec", () => {
         const event = { type: "Hello", data: { hello: new Date() } }
         const encoded = codec.encode(event, undefined)
         // string is not a date
-        expect(() => codec.tryDecode(encoded as any)).toThrow()
+        expect(() => codec.decode(encoded as any)).toThrow()
       })
     })
 
@@ -101,14 +100,14 @@ describe("Codec", () => {
       test("roundtrips", () => {
         const event = { type: "Hello", data: { at: new Date() } }
         const encoded = codec.encode(event, undefined)
-        const decoded = codec.tryDecode(encoded as any)
+        const decoded = codec.decode(encoded as any)
         expect(decoded).toEqual(event)
       })
 
-      test('fails if upcast fails', () => {
+      test("fails if upcast fails", () => {
         const event = { type: "Hello", data: { at: "hello" } }
         const encoded = codec.encode(event, undefined)
-        expect(() => codec.tryDecode(encoded as any)).toThrow()
+        expect(() => codec.decode(encoded as any)).toThrow()
       })
     })
   })

--- a/packages/dynamo-store/indexer/src/AppendsEpoch.ts
+++ b/packages/dynamo-store/indexer/src/AppendsEpoch.ts
@@ -245,7 +245,7 @@ export namespace Reader {
     encode() {
       throw new Error("This is a read only codec")
     },
-    tryDecode(event: ITimelineEvent<string>): Event | undefined {
+    decode(event: ITimelineEvent<string>): Event | undefined {
       const data = JSON.parse(event.data ?? "null")
       return [event.index, { type: event.type, data: data } as Events.Event]
     },

--- a/packages/dynamo-store/indexer/src/AppendsIndex.test.ts
+++ b/packages/dynamo-store/indexer/src/AppendsIndex.test.ts
@@ -20,7 +20,7 @@ test("Deserialises with upconversion", () => {
     encoding: 1,
     body: zlib.deflateRawSync(Buffer.from(JSON.stringify({ tranche: 3, epoch: 2 }))),
   }
-  const dec = AppendsIndex.Events.codec.tryDecode({ type: "Started", data } as any)
+  const dec = AppendsIndex.Events.codec.decode({ type: "Started", data } as any)
   expect(dec).toEqual({ type: "Started", data: { partition: 3, epoch: 2 } })
 })
 
@@ -30,7 +30,7 @@ test("Roundtrips Started cleanly", () => {
     data: { partition: AppendsPartitionId.wellKnownId, epoch: AppendsEpochId.parse("3") },
   }
   const enc = AppendsIndex.Events.codec.encode(event, null)
-  const dec = AppendsIndex.Events.codec.tryDecode(enc as any)
+  const dec = AppendsIndex.Events.codec.decode(enc as any)
   expect(dec).toEqual(event)
 })
 test("Roundtrips Snapshotted cleanly", () => {
@@ -39,6 +39,6 @@ test("Roundtrips Snapshotted cleanly", () => {
     data: { active: { [AppendsPartitionId.parse("0")]: AppendsEpochId.parse("2") } },
   }
   const enc = AppendsIndex.Events.codec.encode(event, null)
-  const dec = AppendsIndex.Events.codec.tryDecode(enc as any)
+  const dec = AppendsIndex.Events.codec.decode(enc as any)
   expect(dec).toEqual(event)
 })

--- a/packages/memory-store/src/index.ts
+++ b/packages/memory-store/src/index.ts
@@ -84,7 +84,7 @@ class Category<Event, State, Context, Format>
   private decodeEvents(encoded: ITimelineEvent<Format>[]) {
     const events: Event[] = []
     for (const ev of encoded) {
-      const decoded = this.codec.tryDecode(ev)
+      const decoded = this.codec.decode(ev)
       if (decoded != null) events.push(decoded)
     }
     return events

--- a/packages/message-db/message-db/src/lib/Snapshot.ts
+++ b/packages/message-db/message-db/src/lib/Snapshot.ts
@@ -16,11 +16,11 @@ export const meta = (token: StreamToken): Meta => ({
   streamVersion: String(Token.streamVersion(token)),
 })
 export async function decode<V>(
-  tryDecode: (ev: ITimelineEvent<Format>) => Promise<V | null | undefined> | V | null | undefined,
+  decode: (ev: ITimelineEvent<Format>) => Promise<V | null | undefined> | V | null | undefined,
   events: ITimelineEvent<Format>[],
 ): Promise<[StreamToken, V] | null> {
   if (events.length > 0) {
-    const decoded = await tryDecode(events[0])
+    const decoded = await decode(events[0])
     if (decoded != null) return [Token.create(streamVersion(events[0])), decoded]
   }
   return null


### PR DESCRIPTION
this reduces confusion as `tryDecode` can actually throw an exception
and the undefined return value is to indicate that the event, while
valid (probably at some other time in the past), should be ignored
