### PR TITLE
feat: improve context to allow proper correlation tracking

### DIFF
--- a/apps/example/src/context/context.ts
+++ b/apps/example/src/context/context.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "crypto"
+import { ITimelineEvent } from "@equinox-js/core"
+
+export type CorrelationContext = {
+  $correlationId?: string
+  $causationId?: string
+}
+
+export type Context = {
+  event?: ITimelineEvent
+}
+
+export namespace Context {
+  export const create = () => {
+    const id = randomUUID()
+    return { id, meta: { $correlationId: id, $causationId: id } }
+  }
+
+  const follow = (ev: ITimelineEvent) => {
+    const meta = ev.meta ? JSON.parse(ev.meta) : {}
+
+    return {
+      $correlationId: meta.$correlationId,
+      $causationId: ev.id,
+    }
+  }
+
+  export const map = (_ev: unknown, ctx: Context) => {
+    if (ctx.event) {
+      return { meta: follow(ctx.event) }
+    }
+    return create()
+  }
+}

--- a/apps/example/src/domain/invoice.ts
+++ b/apps/example/src/domain/invoice.ts
@@ -3,6 +3,7 @@ import z from "zod"
 import { Codec, Decider, LoadOption, StreamId, StreamName } from "@equinox-js/core"
 import { reduce } from "ramda"
 import * as Config from "../config/equinox.js"
+import { Context } from "../context/context.js"
 
 export namespace Stream {
   export const CATEGORY = "Invoice"
@@ -31,7 +32,7 @@ export namespace Events {
     | { type: "InvoiceFinalized" }
 
   export const codec = Codec.upcast<Event>(
-    Codec.json(),
+    Codec.json(Context.create),
     Codec.Upcast.body({
       InvoiceRaised: InvoiceRaised.parse,
       PaymentReceived: Payment.parse,

--- a/apps/example/src/domain/payer.ts
+++ b/apps/example/src/domain/payer.ts
@@ -3,6 +3,7 @@ import { PayerId } from "./identifiers.js"
 import z from "zod"
 import { equals } from "ramda"
 import * as Config from "../config/equinox.js"
+import { Context } from "../context/context.js"
 
 export namespace Stream {
   export const category = "Payer"
@@ -22,7 +23,7 @@ export namespace Events {
   export type Event = { type: "PayerProfileUpdated"; data: PayerProfile } | { type: "PayerDeleted" }
 
   export const codec = Codec.upcast<Event>(
-    Codec.json(),
+    Codec.json(Context.create),
     Codec.Upcast.body({
       PayerProfileUpdated: PayerProfile.parse,
       PayerDeleted: () => undefined,

--- a/apps/example/test/domain/invoice-auto-emailer.test.ts
+++ b/apps/example/test/domain/invoice-auto-emailer.test.ts
@@ -14,7 +14,7 @@ describe("Invoice auto emailer", () => {
     const invoiceId = InvoiceId.create()
     const payerId = PayerId.create()
     const emailer = InvoiceAutoEmailer.Service.create(config)
-    await emailer.sendEmail(invoiceId, payerId, 100)
+    await emailer.sendEmail({}, invoiceId, payerId, 100)
     expect(await emailer.inspectState(invoiceId)).toEqual({
       type: "EmailSendingFailed",
       data: { payer_id: payerId, reason: "Payer not found" },
@@ -27,7 +27,7 @@ describe("Invoice auto emailer", () => {
     const payers = Payer.Service.create(config)
     const emailer = InvoiceAutoEmailer.Service.create(config)
     await payers.updateProfile(payerId, profile)
-    await emailer.sendEmail(invoiceId, payerId, 100)
+    await emailer.sendEmail({}, invoiceId, payerId, 100)
     expect(await emailer.inspectState(invoiceId)).toEqual({
       type: "EmailSent",
       data: { email: profile.email, payer_id: payerId },
@@ -42,7 +42,7 @@ describe("Invoice auto emailer", () => {
       sendEmail: () => Promise.reject(new Error("Test failure")),
     })
     await payers.updateProfile(payerId, profile)
-    await emailer.sendEmail(invoiceId, payerId, 100)
+    await emailer.sendEmail({}, invoiceId, payerId, 100)
     expect(await emailer.inspectState(invoiceId)).toEqual({
       type: "EmailSendingFailed",
       data: { payer_id: payerId, reason: "Test failure" },

--- a/apps/example/test/domain/invoice.test.ts
+++ b/apps/example/test/domain/invoice.test.ts
@@ -16,7 +16,7 @@ const raised: Events.Event = {
 
 describe("Codec", () => {
   test("roundtrips", () => {
-    const encoded = Events.codec.encode(raised, null)
+    const encoded = Events.codec.encode(raised)
     const decoded = Events.codec.decode(encoded as any)
     expect(decoded).toEqual(raised)
   })

--- a/apps/example/test/domain/payer.test.ts
+++ b/apps/example/test/domain/payer.test.ts
@@ -14,7 +14,7 @@ const updated: Payer.Events.Event = {
 
 describe("Codec", () => {
   test("roundtrips", () => {
-    const encoded = Payer.Events.codec.encode(updated, null)
+    const encoded = Payer.Events.codec.encode(updated)
     const decoded = Payer.Events.codec.decode(encoded as any)
     expect(decoded).toEqual(updated)
   })

--- a/apps/example/test/read-models/PayerReadModel.test.ts
+++ b/apps/example/test/read-models/PayerReadModel.test.ts
@@ -57,7 +57,7 @@ function scenario(name: string, batches: [StreamName, ITimelineEvent[]][] = [], 
           [
             streamName,
             events.map((event) => {
-              const encoded = Payer.Events.codec.encode(event, null) as ITimelineEvent
+              const encoded = Payer.Events.codec.encode(event) as ITimelineEvent
               encoded.index = BigInt(version++)
               return encoded
             }),

--- a/docs/docs/core-concepts/codec.md
+++ b/docs/docs/core-concepts/codec.md
@@ -80,7 +80,7 @@ const codec = Codec.map(
 ```
 
 When upcasting is used, the `decode` method of the resulting codec will drop
-events whose types are not included in the mapping. This is because it's a 
+events whose types are not included in the mapping. This is because it's a
 common evolution in event sourced systems for events to become dead weight, or
 unnecessary. By providing an upcast mapping you've essentially defined exactly
 the events you care about and the codec will respect that by returning `undefined`
@@ -103,24 +103,23 @@ record this information on our domain event type.
 
 ```ts
 type Meta = { userId: string }
-type Event =
-  | {type: 'SomethingHappened', data: { what: string }, meta: Meta }
+type Event = { type: "SomethingHappened"; data: { what: string }; meta: Meta }
 ```
 
 The second and preferred option is to use the `Context` variable. You can
 map the event and context to a metadata type.
 
 ```ts
-type Context = { tenantId: string, correlationId: string; causationId: string; userId: string }
-type Event =
-  | {type: 'SomethingHappened', data: { what: string } }
+type Context = { tenantId: string; correlationId: string; causationId: string; userId: string }
+type Event = { type: "SomethingHappened"; data: { what: string } }
 
-const mapMeta = (ev: Event, ctx: Context) => ({ 
-  // matches ESDB conventions
-  $correlationId: ctx.correlationId,
-  $causationId: ctx.causationId,
-  userId: ctx.userId,
-  // ignore tenant as that's going to be on the stream id
+const mapMeta = (ev: Event, ctx: Context) => ({
+  meta: {
+    // matches ESDB conventions
+    $correlationId: ctx.correlationId,
+    $causationId: ctx.causationId,
+    userId: ctx.userId,
+  },
 })
 
 const codec = Codec.json<Event, Context>(mapMeta)
@@ -131,4 +130,3 @@ The `Context` is supplied at decider resolution time
 ```ts
 Decider.forStream(category, streamId, context)
 ```
-

--- a/packages/core/src/lib/Category.ts
+++ b/packages/core/src/lib/Category.ts
@@ -4,7 +4,7 @@ import * as Tags from './Tags.js'
 import { StreamId } from "./StreamId.js"
 
 /** Store-agnostic interface representing interactions an Application can have with a set of streams with a given pair of Event and State types */
-export interface ICategory<Event, State, Context = null> {
+export interface ICategory<Event, State, Context = void> {
   /** Obtain the state from the target stream */
   load(streamId: StreamId, maxStaleMs: number, requireLeader: boolean): Promise<TokenAndState<State>>
 
@@ -22,7 +22,7 @@ export interface ICategory<Event, State, Context = null> {
   ): Promise<SyncResult<State>>
 }
 
-export class Category<Event, State, Context = null> {
+export class Category<Event, State, Context = void> {
   constructor(
     private readonly inner: ICategory<Event, State, Context>,
     private readonly empty: TokenAndState<State>,


### PR DESCRIPTION
This change allows proper tracking of correlation ids for equinox projects. Before this change we couldn't control the ID of the event in `mapMeta` which made for some difficulties initialising the correlation context (the first event in the chain has `id = corrId = causId` so instead of restricting mapMeta to provide meta, we allow it to map both the ID and the meta. (Potential rename to `mapCausation`)