### PR TITLE
feat: Support ttl for the cache

### DIFF
--- a/docs/docs/core-concepts/caching.md
+++ b/docs/docs/core-concepts/caching.md
@@ -40,3 +40,18 @@ Retain a single `state` per `stream_name` in the supplied cache.
 
 Prefix is used to segregate multiple folds per stream when they are stored in the cache.
 
+## `CacheTtl(cache, ttlInMs, ?prefix)`
+
+```ts
+import { CachingStrategy, MemoryCache } from "@equinox-js/core"
+const cache = new MemoryCache()
+const MINUTE = 60 * 1000
+const strategy = CachingStrategy.CacheTtl(cache, 20 * MINUTE)
+```
+
+Retain a single `state` per `stream_name` in the supplied cache. The cache is
+purged of stale items on a 5 second interval.
+
+Prefix is used to segregate multiple folds per stream when they are stored in
+the cache.
+

--- a/packages/core/src/lib/Cache.ts
+++ b/packages/core/src/lib/Cache.ts
@@ -74,9 +74,8 @@ export class MemoryCache implements ICache {
   }
 
   private startPurgeTimer() {
-    setTimeout(() => {
+    setInterval(() => {
       this.cache.purgeStale()
-      this.startPurgeTimer()
     }, 5000).unref()
   }
 
@@ -122,7 +121,7 @@ export class MemoryCache implements ICache {
     if (age < skipReloadIfYoungerThanMs) {
       return current.value()
     }
-    return this.readWithExactlyOneFetch(key, supersedes, () => read(current.value()))
+    return this.readWithExactlyOneFetch(key, supersedes, () => read(current.value()), ttl)
   }
 
   updateIfNewer<State>(

--- a/packages/core/test/Cache.test.ts
+++ b/packages/core/test/Cache.test.ts
@@ -49,6 +49,24 @@ describe("Caching", () => {
     const p3 = cache.readThrough("1", anyValue, supersedes, reload)
     await Promise.all([p1, p2, p3])
   })
+
+  describe("ttl", () => {
+    test("evicts stale entries", async () => {
+      const cache = new Cache.MemoryCache(5)
+      const read1 = vi.fn().mockImplementation(read(1n))
+      const read2 = vi.fn().mockImplementation(read(1n))
+      await cache.readThrough("1", anyValue, read1, 1)
+      // noTTL
+      await cache.readThrough("2", anyValue, read2)
+      await sleep(2)
+      // this will get called every 5s, we're just speeding it up for the purposes of this test
+      cache["cache"].purgeStale()
+      await cache.readThrough("1", anyValue, read1, 1)
+      await cache.readThrough("2", anyValue, read2)
+      expect(read1).toHaveBeenCalledTimes(2)
+      expect(read2).toHaveBeenCalledTimes(1)
+    })
+  })
 })
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))

--- a/packages/core/test/Cache.test.ts
+++ b/packages/core/test/Cache.test.ts
@@ -55,14 +55,14 @@ describe("Caching", () => {
       const cache = new Cache.MemoryCache(5)
       const read1 = vi.fn().mockImplementation(read(1n))
       const read2 = vi.fn().mockImplementation(read(1n))
-      await cache.readThrough("1", anyValue, read1, 1)
+      await cache.readThrough("1", anyValue, supersedes, read1, 1)
       // noTTL
-      await cache.readThrough("2", anyValue, read2)
+      await cache.readThrough("2", anyValue, supersedes, read2)
       await sleep(2)
       // this will get called every 5s, we're just speeding it up for the purposes of this test
       cache["cache"].purgeStale()
-      await cache.readThrough("1", anyValue, read1, 1)
-      await cache.readThrough("2", anyValue, read2)
+      await cache.readThrough("1", anyValue, supersedes, read1, 1)
+      await cache.readThrough("2", anyValue, supersedes, read2)
       expect(read1).toHaveBeenCalledTimes(2)
       expect(read2).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
Add support for ttl in the caching strategy. Allows us to keep the memory consumption down by purging stale items from the cache. Though, as it is an LRU, maybe people should just a lower `max`