### PR TITLE
feat: MessageDB consistency improvements

### DIFF
--- a/packages/message-db/message-db-consumer/tests/reader.test.mts
+++ b/packages/message-db/message-db-consumer/tests/reader.test.mts
@@ -14,7 +14,7 @@ describe("MessageDbCategoryReader", () => {
   const streamId = StreamId.create(randomUUID().replace(/-/g, ""))
   const streamName = StreamName.create(category, streamId)
   beforeAll(async () => {
-    await conn.write.writeMessages(streamName, Array(100).fill({ type: "TestEvent" }), -1n)
+    await conn.write.writeMessages(streamName, Array(100).fill({ type: "TestEvent" }), 0n)
     await conn.write.writeSingleMessage(streamName, { type: "ExclusiveEvent" }, null)
   })
   test("Can read a category", async () => {

--- a/packages/message-db/message-db/src/lib/Category.ts
+++ b/packages/message-db/message-db/src/lib/Category.ts
@@ -57,29 +57,21 @@ export class MessageDbContext {
     decode: Decode<Event>,
     fold: (state: State, events: Event[]) => State,
     initial: State,
+    version = 0n,
   ): Promise<[StreamToken, State]> {
     let state = initial
-    let version = -1n
-    let batches = 0
-    let eventCount = 0
     for await (const [lastVersion, events] of Read.loadForwardsFrom(
       this.conn.read,
       this.batchSize,
       this.maxBatches,
       streamName,
-      0n,
+      version,
       requireLeader,
     )) {
-      batches++
-      eventCount += events.length
       state = fold(state, keepMap(events, decode))
       version = lastVersion
     }
-    trace.getActiveSpan()?.setAttributes({
-      [Tags.loaded_count]: eventCount,
-      [Tags.batches]: batches,
-      [Tags.read_version]: Number(version),
-    })
+
     return [Token.create(version), state]
   }
 
@@ -91,10 +83,6 @@ export class MessageDbContext {
     initial: State,
   ): Promise<[StreamToken, State]> {
     const [version, events] = await Read.loadLastEvent(this.conn.read, requireLeader, streamName)
-    trace.getActiveSpan()?.setAttributes({
-      [Tags.loaded_count]: 1,
-      [Tags.read_version]: Number(version),
-    })
     return [Token.create(version), fold(initial, keepMap(events, decode))]
   }
 
@@ -112,43 +100,11 @@ export class MessageDbContext {
       snapshotStream,
       eventType,
     )
-    const decoded = await Snapshot.decode(decode, events)
+    const decoded = Snapshot.decode(decode, events)
     trace.getActiveSpan()?.setAttributes({
-      [Tags.snapshot_version]: decoded ? Number(decoded?.[0].version) : -1,
+      [Tags.snapshot_version]: decoded ? Number(decoded?.[0].version) : 0,
     })
     return decoded
-  }
-
-  async reload<Event, State>(
-    streamName: Equinox.StreamName,
-    requireLeader: boolean,
-    token: StreamToken,
-    decode: Decode<Event>,
-    fold: (state: State, events: Event[]) => State,
-    state: State,
-  ): Promise<[StreamToken, State]> {
-    let streamVersion = Token.streamVersion(token)
-    const startPos = streamVersion + 1n // Reading a stream uses {inclusive} positions, but the streamVersion is `-1`-based
-    let batches = 0
-    let eventCount = 0
-    for await (const [version, events] of Read.loadForwardsFrom(
-      this.conn.read,
-      this.batchSize,
-      this.maxBatches,
-      streamName,
-      startPos,
-      requireLeader,
-    )) {
-      state = fold(state, keepMap(events, decode))
-      streamVersion = streamVersion > version ? streamVersion : version
-      batches++
-      eventCount += events.length
-    }
-    trace.getActiveSpan()?.setAttributes({
-      [Tags.loaded_count]: eventCount,
-      [Tags.batches]: batches,
-    })
-    return [Token.create(streamVersion), state]
   }
 
   async sync(
@@ -158,11 +114,12 @@ export class MessageDbContext {
     runAfter?: (conn: Client) => Promise<void>,
   ): Promise<GatewaySyncResult> {
     const span = trace.getActiveSpan()
-    const streamVersion = Token.streamVersion(token)
-    const appendedTypes = new Set(encodedEvents.map((x) => x.type))
-    if (appendedTypes.size <= 10) {
-      span?.setAttribute(Tags.append_types, Array.from(appendedTypes))
-    }
+    const streamVersion = Token.maxIndex(token)
+    const appendedTypes = encodedEvents.map((x) => x.type)
+    span?.setAttribute(
+      Tags.append_types,
+      appendedTypes.length < 10 ? appendedTypes : uniq(appendedTypes),
+    )
     const result = await this.conn.write.writeMessages(
       streamName,
       encodedEvents,
@@ -175,7 +132,7 @@ export class MessageDbContext {
         span?.addEvent("Conflict")
         return { type: "ConflictUnknown" }
       case "Written": {
-        const token = Token.create(result.position)
+        const token = Token.create(result.version)
         return { type: "Written", token }
       }
     }
@@ -193,8 +150,12 @@ export class MessageDbContext {
   }
 }
 
-
-export type OnSync<State> = (conn: Client, streamId: Equinox.StreamId, state: State, version: bigint) => Promise<void>
+export type OnSync<State> = (
+  conn: Client,
+  streamId: Equinox.StreamId,
+  state: State,
+  version: bigint,
+) => Promise<void>
 
 export type AccessStrategy<Event, State> =
   | { type: "Unoptimized" }
@@ -280,13 +241,13 @@ class InternalCategory<Event, State, Context>
           )
         const [pos, snapshotEvent] = result
         const initial = this.fold(this.initial, [snapshotEvent])
-        const [token, state] = await this.context.reload(
+        const [token, state] = await this.context.loadBatched(
           streamName,
           requireLeader,
-          pos,
           this.codec.decode,
           this.fold,
           initial,
+          Token.version(pos),
         )
         return [Token.withSnapshot(token, pos.version), state]
       }
@@ -302,13 +263,13 @@ class InternalCategory<Event, State, Context>
 
   async reload(streamId: Equinox.StreamId, requireLeader: boolean, t: TokenAndState<State>) {
     const streamName = Equinox.StreamName.create(this.categoryName, streamId)
-    const [token, state] = await this.context.reload(
+    const [token, state] = await this.context.loadBatched(
       streamName,
       requireLeader,
-      t.token,
       this.codec.decode,
       this.fold,
       t.state,
+      Token.version(t.token),
     )
     return { token, state }
   }
@@ -331,7 +292,8 @@ class InternalCategory<Event, State, Context>
     const newState = this.fold(state, events)
     const newVersion = token.version + BigInt(events.length)
     const onSync = this.onSync
-    const runInSameTransaction = onSync && ((conn: Client) => onSync(conn, streamId, newState, newVersion))
+    const runInSameTransaction =
+      onSync && ((conn: Client) => onSync(conn, streamId, newState, newVersion))
     const result = await this.context.sync(streamName, token, encodedEvents, runInSameTransaction)
     switch (result.type) {
       case "ConflictUnknown":
@@ -393,4 +355,17 @@ export class MessageDbCategory {
     const empty: TokenAndState<State> = { token: context.tokenEmpty, state: initial }
     return new Equinox.Category(category, empty)
   }
+}
+
+// uniques an array while preserving order
+function uniq<T>(arr: T[]): T[] {
+  const set = new Set<T>()
+  const result: T[] = []
+  for (const item of arr) {
+    if (!set.has(item)) {
+      set.add(item)
+      result.push(item)
+    }
+  }
+  return result
 }

--- a/packages/message-db/message-db/src/lib/Category.ts
+++ b/packages/message-db/message-db/src/lib/Category.ts
@@ -17,7 +17,7 @@ import { CachingCategory, ICachingStrategy, IReloadableCategory, Tags } from "@e
 
 const keepMap = Equinox.Internal.keepMap
 
-type GatewaySyncResult = { type: "Written"; token: StreamToken } | { type: "ConflictUnknown" }
+type MdbSyncResult = { type: "Written"; token: StreamToken } | { type: "ConflictUnknown" }
 
 type Decode<E> = (v: ITimelineEvent<Format>) => E | undefined
 
@@ -112,9 +112,9 @@ export class MessageDbContext {
     token: StreamToken,
     encodedEvents: IEventData<Format>[],
     runAfter?: (conn: Client) => Promise<void>,
-  ): Promise<GatewaySyncResult> {
+  ): Promise<MdbSyncResult> {
     const span = trace.getActiveSpan()
-    const streamVersion = Token.maxIndex(token)
+    const version = Token.version(token)
     const appendedTypes = encodedEvents.map((x) => x.type)
     span?.setAttribute(
       Tags.append_types,
@@ -123,7 +123,7 @@ export class MessageDbContext {
     const result = await this.conn.write.writeMessages(
       streamName,
       encodedEvents,
-      streamVersion,
+      version,
       runAfter,
     )
 

--- a/packages/message-db/message-db/src/lib/Category.ts
+++ b/packages/message-db/message-db/src/lib/Category.ts
@@ -120,12 +120,8 @@ export class MessageDbContext {
       Tags.append_types,
       appendedTypes.length < 10 ? appendedTypes : uniq(appendedTypes),
     )
-    const result = await this.conn.write.writeMessages(
-      streamName,
-      encodedEvents,
-      version,
-      runAfter,
-    )
+    // prettier-ignore
+    const result = await this.conn.write.writeMessages(streamName, encodedEvents, version, runAfter)
 
     switch (result.type) {
       case "ConflictUnknown":

--- a/packages/message-db/message-db/src/lib/MessageDbClient.ts
+++ b/packages/message-db/message-db/src/lib/MessageDbClient.ts
@@ -35,16 +35,19 @@ export class MessageDbWriter {
     }
   }
 
+  // Note: MessageDB version is -1 based, equinox version is 0 based
+  // This function is never called with 0 events
   async writeMessages(
     streamName: string,
     messages: IEventData<Format>[],
-    expectedVersion: bigint | null,
+    equinoxOriginVersion: bigint | null,
     runInSameTransaction?: (client: Client) => Promise<void>,
   ): Promise<MdbWriteResult> {
+    let expectedVersion = equinoxOriginVersion == null ? null : equinoxOriginVersion - 1n
     if (messages.length === 1 && !runInSameTransaction)
       return this.writeSingleMessage(streamName, messages[0], expectedVersion)
     const client = await this.pool.connect()
-    let position = -1n
+    let position = 0n
     try {
       await client.query("BEGIN")
 

--- a/packages/message-db/message-db/src/lib/Read.ts
+++ b/packages/message-db/message-db/src/lib/Read.ts
@@ -3,15 +3,15 @@ import { Format, MessageDbReader } from "./MessageDbClient.js"
 import { trace } from "@opentelemetry/api"
 import { Tags } from "@equinox-js/core"
 
-type StreamEventsSlice = {
+type Batch = {
   messages: ITimelineEvent<Format>[]
   isEnd: boolean
-  lastVersion: bigint
+  version: bigint
 }
 
-const toSlice = (events: ITimelineEvent<Format>[], isLast: boolean): StreamEventsSlice => {
-  const lastVersion = events.length === 0 ? -1n : events[events.length - 1].index
-  return { messages: events, isEnd: isLast, lastVersion }
+const toBatch = (events: ITimelineEvent<Format>[], isLast: boolean): Batch => {
+  const version = events.length === 0 ? 0n : events[events.length - 1].index + 1n
+  return { messages: events, isEnd: isLast, version }
 }
 
 const readSliceAsync = async (
@@ -23,7 +23,7 @@ const readSliceAsync = async (
 ) => {
   const page = await reader.readStream(streamName, startPos, batchSize, requiresLeader)
   const isLast = page.length < batchSize
-  return toSlice(page, isLast)
+  return toBatch(page, isLast)
 }
 
 const readLastEventAsync = async (
@@ -31,13 +31,13 @@ const readLastEventAsync = async (
   streamName: string,
   requiresLeader: boolean,
   eventType?: string,
-): Promise<StreamEventsSlice> => {
+): Promise<Batch> => {
   const events = await reader.readLastEvent(streamName, requiresLeader, eventType)
-  return toSlice(events == null ? [] : [events], false)
+  return toBatch(events == null ? [] : [events], false)
 }
 
 async function* readBatches(
-  readSlice: (start: bigint) => Promise<StreamEventsSlice>,
+  readSlice: (start: bigint) => Promise<Batch>,
   maxPermittedReads: number | undefined,
   startPosition: bigint,
 ): AsyncIterable<[bigint, ITimelineEvent[]]> {
@@ -45,23 +45,25 @@ async function* readBatches(
   let batchCount = 0
   let eventCount = 0
   let bytes = 0
-  let slice: StreamEventsSlice
+  let slice: Batch
   do {
     if (maxPermittedReads && batchCount >= maxPermittedReads)
       throw new Error("Batch limit exceeded")
     slice = await readSlice(startPosition)
-    yield [slice.lastVersion, slice.messages]
+    if (slice.messages.length > 0) {
+      yield [slice.version, slice.messages]
+    }
     batchCount++
     eventCount += slice.messages.length
     bytes += slice.messages.reduce((acc, m) => acc + m.size, 0)
-    startPosition = slice.lastVersion + 1n
+    startPosition = slice.version
   } while (!slice.isEnd)
 
   span?.setAttributes({
     [Tags.batches]: batchCount,
     [Tags.loaded_bytes]: bytes,
     [Tags.loaded_count]: eventCount,
-    [Tags.read_version]: String(slice.lastVersion),
+    [Tags.read_version]: String(slice.version),
   })
 }
 
@@ -70,20 +72,20 @@ export function loadForwardsFrom(
   batchSize: number,
   maxPermittedBatchReads: number | undefined,
   streamName: string,
-  startPosition: bigint,
+  minIndex: bigint,
   requiresLeader: boolean,
 ) {
   const span = trace.getActiveSpan()
   span?.setAttributes({
     [Tags.batch_size]: batchSize,
-    [Tags.loaded_from_version]: String(startPosition),
+    [Tags.loaded_from_version]: String(minIndex),
     [Tags.load_method]: "BatchForward",
     [Tags.requires_leader]: requiresLeader,
   })
   const readSlice = (start: bigint) =>
     readSliceAsync(reader, streamName, batchSize, start, requiresLeader)
 
-  return readBatches(readSlice, maxPermittedBatchReads, startPosition)
+  return readBatches(readSlice, maxPermittedBatchReads, minIndex)
 }
 
 export async function loadLastEvent(
@@ -96,8 +98,8 @@ export async function loadLastEvent(
   span?.setAttribute(Tags.load_method, "Last")
   const s = await readLastEventAsync(reader, streamName, requiresLeader, eventType)
   span?.setAttributes({
-    [Tags.read_version]: Number(s.lastVersion),
+    [Tags.read_version]: Number(s.version),
     [Tags.loaded_count]: s.messages.length,
   })
-  return [s.lastVersion, s.messages] as const
+  return [s.version, s.messages] as const
 }

--- a/packages/message-db/message-db/src/lib/Token.ts
+++ b/packages/message-db/message-db/src/lib/Token.ts
@@ -1,20 +1,21 @@
 import { StreamToken } from "@equinox-js/core"
 
-type TokenValue = { version: bigint; snapshot_version?: bigint }
+type TokenValue = { max_index: bigint; snapshot_version?: bigint }
 
-export const create = (version: bigint, snapshot?: bigint): StreamToken => ({
-  value: { version, snapshot_version: snapshot },
-  version: version + 1n,
+export const create = (version: bigint, snapshot_version?: bigint): StreamToken => ({
+  value: { max_index: version - 1n, snapshot_version } satisfies TokenValue,
+  version: version,
   bytes: -1n,
 })
 const tokenValue = (token: StreamToken) => token.value as TokenValue
-export const streamVersion = (token: StreamToken) => tokenValue(token).version
+export const version = (token: StreamToken) => token.version
+export const maxIndex = (token: StreamToken) => tokenValue(token).max_index
 export const snapshotVersion = (token: StreamToken) => tokenValue(token).snapshot_version ?? 0n
 
 export const withSnapshot = (token: StreamToken, snapshot: bigint) => {
   const value = tokenValue(token)
   return {
-    value: { version: value.version, snapshot_version: snapshot },
+    value: { version: value.max_index, snapshot_version: snapshot },
     version: token.version,
     bytes: -1n,
   }

--- a/packages/message-db/message-db/test/message-db.test.ts
+++ b/packages/message-db/message-db/test/message-db.test.ts
@@ -500,11 +500,11 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
       {
         name: "Transact",
         [Tags.loaded_count]: 0,
-        [Tags.snapshot_version]: -1,
+        [Tags.snapshot_version]: 0,
         [Tags.append_count]: 8,
         [Tags.snapshot_written]: false,
       },
-      { name: "Query", [Tags.loaded_count]: 8, [Tags.snapshot_version]: -1 },
+      { name: "Query", [Tags.loaded_count]: 8, [Tags.snapshot_version]: 0 },
     )
 
     // Add two more, which should push it over the threshold and hence trigger an append of a snapshot event
@@ -513,7 +513,7 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     assertSpans({
       name: "Transact",
       [Tags.loaded_count]: 8,
-      [Tags.snapshot_version]: -1,
+      [Tags.snapshot_version]: 0,
       [Tags.append_count]: 2,
       [Tags.snapshot_written]: true,
     })
@@ -585,10 +585,10 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
       {
         name: "Transact",
         [Tags.loaded_count]: 0,
-        [Tags.snapshot_version]: -1,
+        [Tags.snapshot_version]: 0,
         [Tags.snapshot_written]: false,
       },
-      { name: "Query", [Tags.loaded_count]: 8, [Tags.snapshot_version]: -1 },
+      { name: "Query", [Tags.loaded_count]: 8, [Tags.snapshot_version]: 0 },
     )
 
     // Add two more, which should push it over the threshold and hence trigger generation of a snapshot event
@@ -597,7 +597,7 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     assertSpans({
       name: "Transact",
       [Tags.loaded_count]: 8,
-      [Tags.snapshot_version]: -1,
+      [Tags.snapshot_version]: 0,
       [Tags.snapshot_written]: true,
     })
 

--- a/packages/message-db/message-db/test/snapshot.test.ts
+++ b/packages/message-db/message-db/test/snapshot.test.ts
@@ -4,50 +4,35 @@ import { test, expect } from "vitest"
 import * as Snapshot from "../src/lib/Snapshot.js"
 import * as Token from "../src/lib/Token.js"
 
-test("Properly loads snapshot version from previous schema", async () => {
-  const event: ITimelineEvent = {
-    id: randomUUID(),
-    index: 0n,
-    isUnfold: true,
-    size: 0,
-    time: new Date(),
-    type: "Snapshotted",
-    data: JSON.stringify({ hello: "world" }),
-    meta: JSON.stringify({ streamVersion: "0" }),
-  }
+const createEvent = (meta: Snapshot.Meta): ITimelineEvent => ({
+  id: randomUUID(),
+  index: 0n,
+  isUnfold: true,
+  size: 0,
+  time: new Date(),
+  type: "Snapshotted",
+  data: JSON.stringify({ hello: "world" }),
+  meta: JSON.stringify(meta),
+})
 
+test("Properly loads snapshot version from previous schema", async () => {
+  const event = createEvent({ streamVersion: "10" })
   const codec = Codec.json<any>()
 
   const decoded = Snapshot.decode(codec.decode, [event])
   if (decoded == null) throw new Error("Expected snapshot to be decoded")
   const [token, value] = decoded
-  expect(Token.version(token)).toBe(1n)
-  expect(value).toEqual({
-    type: "Snapshotted",
-    data: { hello: "world" },
-  })
+  expect(Token.version(token)).toBe(11n)
+  expect(value).toEqual({ type: "Snapshotted", data: { hello: "world" } })
 })
 
 test("Properly loads snapshot version from new schema", async () => {
-  const event: ITimelineEvent = {
-    id: randomUUID(),
-    index: 0n,
-    isUnfold: true,
-    size: 0,
-    time: new Date(),
-    type: "Snapshotted",
-    data: JSON.stringify({ hello: "world" }),
-    meta: JSON.stringify({ version: "10" }),
-  }
-
+  const event = createEvent({ version: "10" })
   const codec = Codec.json<any>()
 
   const decoded = Snapshot.decode(codec.decode, [event])
   if (decoded == null) throw new Error("Expected snapshot to be decoded")
   const [token, value] = decoded
   expect(Token.version(token)).toBe(10n)
-  expect(value).toEqual({
-    type: "Snapshotted",
-    data: { hello: "world" },
-  })
+  expect(value).toEqual({ type: "Snapshotted", data: { hello: "world" } })
 })

--- a/packages/message-db/message-db/test/snapshot.test.ts
+++ b/packages/message-db/message-db/test/snapshot.test.ts
@@ -1,0 +1,53 @@
+import { Codec, ITimelineEvent } from "@equinox-js/core"
+import { randomUUID } from "crypto"
+import { test, expect } from "vitest"
+import * as Snapshot from "../src/lib/Snapshot.js"
+import * as Token from "../src/lib/Token.js"
+
+test("Properly loads snapshot version from previous schema", async () => {
+  const event: ITimelineEvent = {
+    id: randomUUID(),
+    index: 0n,
+    isUnfold: true,
+    size: 0,
+    time: new Date(),
+    type: "Snapshotted",
+    data: JSON.stringify({ hello: "world" }),
+    meta: JSON.stringify({ streamVersion: "0" }),
+  }
+
+  const codec = Codec.json<any>()
+
+  const decoded = Snapshot.decode(codec.decode, [event])
+  if (decoded == null) throw new Error("Expected snapshot to be decoded")
+  const [token, value] = decoded
+  expect(Token.version(token)).toBe(1n)
+  expect(value).toEqual({
+    type: "Snapshotted",
+    data: { hello: "world" },
+  })
+})
+
+test("Properly loads snapshot version from new schema", async () => {
+  const event: ITimelineEvent = {
+    id: randomUUID(),
+    index: 0n,
+    isUnfold: true,
+    size: 0,
+    time: new Date(),
+    type: "Snapshotted",
+    data: JSON.stringify({ hello: "world" }),
+    meta: JSON.stringify({ version: "10" }),
+  }
+
+  const codec = Codec.json<any>()
+
+  const decoded = Snapshot.decode(codec.decode, [event])
+  if (decoded == null) throw new Error("Expected snapshot to be decoded")
+  const [token, value] = decoded
+  expect(Token.version(token)).toBe(10n)
+  expect(value).toEqual({
+    type: "Snapshotted",
+    data: { hello: "world" },
+  })
+})


### PR DESCRIPTION
This is taking some of the learnings from writing the Sqlite store in #80 and applying them to message-db. Next up we will improve the reload of access strategies like "Snapshot" and "LatestKnownEvent" to not load new events unless necessary